### PR TITLE
Change order of split replacements

### DIFF
--- a/dms2dec
+++ b/dms2dec
@@ -1,4 +1,4 @@
-dms2dec <- function(dms, separators = c("º", "°", "\'", "’", "’’", "\"", "\'\'", "\\?")) {
+dms2dec <- function(dms, separators = c("º", "°","’’", "\'\'","\'", "’",  "\"",  "\\?")) {
   
   # by A. Marcia Barbosa (https://modtools.wordpress.com/)
   # license: CC BY-SA 4.0 (Creative Commons)


### PR DESCRIPTION
Do double quotes and double characters first in loop. Fixes hemisphere allocation